### PR TITLE
Add handling for \r\n mcumgr line endings

### DIFF
--- a/plugins/mcumgr/smp_uart.cpp
+++ b/plugins/mcumgr/smp_uart.cpp
@@ -63,10 +63,16 @@ void smp_uart::serial_read(QByteArray *rec_data)
             //Start
             //Check this header
             SMPBuffer.clear();
+            QByteArray mid = SerialData.mid((pos + 2), (posA - pos - 2));
+            if (mid.endsWith('\r'))
+            {
+                mid.chop(1);
+            }
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            SMPBuffer = QByteArray::fromBase64(SerialData.mid((pos + 2), (posA - pos - 2)), QByteArray::AbortOnBase64DecodingErrors);
+            SMPBuffer = QByteArray::fromBase64(mid, QByteArray::AbortOnBase64DecodingErrors);
 #else
-            SMPBuffer = QByteArray::fromBase64(SerialData.mid((pos + 2), (posA - pos - 2)));
+            SMPBuffer = QByteArray::fromBase64(mid);
 #endif
 
             if (SMPBuffer.length() == 0)
@@ -118,10 +124,15 @@ void smp_uart::serial_read(QByteArray *rec_data)
             //Continuation
             //Check this header
             SMPBuffer.clear();
+            QByteArray mid = SerialData.mid((pos_other + 2), (posA_other - pos_other - 2));
+            if (mid.endsWith('\r'))
+            {
+                mid.chop(1);
+            }
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-            SMPBuffer = QByteArray::fromBase64(SerialData.mid((pos_other + 2), (posA_other - pos_other - 2)), QByteArray::AbortOnBase64DecodingErrors);
+            SMPBuffer = QByteArray::fromBase64(mid, QByteArray::AbortOnBase64DecodingErrors);
 #else
-            SMPBuffer = QByteArray::fromBase64(SerialData.mid((pos_other + 2), (posA_other - pos_other - 2)));
+            SMPBuffer = QByteArray::fromBase64(mid);
 #endif
 
             if (SMPBuffer.length() == 0)


### PR DESCRIPTION
I have somehow ended up with a MCUmgr setup on a device that sends lines ending with \r\n instead of just \n... the [mcumgr](https://github.com/apache/mynewt-mcumgr) cli handles this fine, but AuTerm seems to get stuck as it gets a base64 decoding error once it gets to the \r at the end of the base64-encoded string.
