### PR TITLE
Fix: Resolve invalid use of incomplete type 'class QDebug'

### DIFF
--- a/AuTerm/AutSerialDetect_linux.cpp
+++ b/AuTerm/AutSerialDetect_linux.cpp
@@ -27,6 +27,7 @@
 #include "AutSerialDetect_linux.h"
 #include <QSerialPortInfo>
 #include <QWidget>
+#include <QDebug>
 
 /******************************************************************************/
 // Local Functions or Private Members


### PR DESCRIPTION
This fix ensures proper inclusion of required headers.

Error code:
<html><body><code style="white-space:pre;font-family:Source Code Pro"><a href="olpfile:///home/parallels/git/auterm/AuTerm/AutSerialDetect_linux.cpp::0::0">../../../AuTerm/AutSerialDetect_linux.cpp</a>: In member function ‘virtual void AutSerialDetectWorkerThread::run()’:
<a href="olpfile:///home/parallels/git/auterm/AuTerm/AutSerialDetect_linux.cpp::160::15">../../../AuTerm/AutSerialDetect_linux.cpp</a>:160:15: error: invalid use of incomplete type ‘class QDebug’
  160 |         qDebug() &lt;&lt; &quot;udev_new creation failed&quot;;</code></body></html>